### PR TITLE
Section inlusion|subdividing fixed

### DIFF
--- a/ims/ostis_technology/unificated_models/section_unificated_models_kb/section_subjdomain_knowledges/section_subjdomain_knowledges.scsi
+++ b/ims/ostis_technology/unificated_models/section_unificated_models_kb/section_subjdomain_knowledges/section_subjdomain_knowledges.scsi
@@ -342,7 +342,6 @@ non_atomic_section
 => nrel_idtf:
 	[раздел, декомпозируемый на подразделы]
 	(* <- lang_ru;; *);
-<= nrel_strict_inclusion: section;
 <- rrel_key_sc_element:
 	...
 	(*
@@ -366,7 +365,6 @@ atomic_section
 => nrel_idtf:
 	[раздел, не имеющий подразделов]
 	(* <- lang_ru;; *);
-<= nrel_strict_inclusion: section;
 <- rrel_key_sc_element:
 	...
 	(*


### PR DESCRIPTION
Убрано включение атомарных\неатомарных разделов в раздел, оставлено только разбиение.