### PR TITLE
Hierarchy of semantic neighborhood fixes

### DIFF
--- a/ims/ostis_tech/justification/section_model_of_OSTIS_IS/section_semantic_represent_info_in_sys_memory/sectn_clarif_concepts_semantic_network/sect_clarif_concp_semantic_net.scsi
+++ b/ims/ostis_tech/justification/section_model_of_OSTIS_IS/section_semantic_represent_info_in_sys_memory/sectn_clarif_concepts_semantic_network/sect_clarif_concp_semantic_net.scsi
@@ -1,9 +1,9 @@
 sc_node_not_relation -> semantic_network;;
 semantic_network
 => nrel_main_idtf:
-	[Семантическая сеть]
+	[семантическая сеть]
 	(* <- lang_ru;; *);
-	[Semantic network]
+	[semantic network]
 	(* <- lang_en;; *);;
 
 semantic_network <- rrel_key_sc_element:

--- a/ims/ostis_tech/semantic_network_represent/section_sc_code/section_subjdomain_actions_and_tasks/section_subjdomain_actions_and_tasks.scsi
+++ b/ims/ostis_tech/semantic_network_represent/section_sc_code/section_subjdomain_actions_and_tasks/section_subjdomain_actions_and_tasks.scsi
@@ -1051,10 +1051,7 @@ task
 				"file://content_html/identify_instances_rule_for_task.html"
 			(* <- lang_ru;;	*);;
 		*);;
-	*);	
-	
-<= nrel_inclusion:	
-	semantic_neighborhood;	
+	*);
 
 => nrel_inclusion:	
 	procedural_formulation_of_task;

--- a/ims/ostis_tech/semantic_network_represent/section_sc_code/section_subjdomain_parameters_and_values/section_subjdomain_parameters_and_values.scsi
+++ b/ims/ostis_tech/semantic_network_represent/section_sc_code/section_subjdomain_parameters_and_values/section_subjdomain_parameters_and_values.scsi
@@ -521,9 +521,6 @@ parametric_model
 	[описание сущности как точки в некотором параметрическом (признаковом) пространстве]
 	(* <- lang_ru;; *);
 
-<= nrel_inclusion:
-	semantic_neighborhood;
-
 <- rrel_key_sc_element:
 	...
 	(*

--- a/ims/ostis_tech/unificated_models/section_unificated_models_kb/section_subjdomain_of_logical_formulas_and_logical_ontologies/subject_domain_of_logical_formulas_and_logical_ontologies.scsi
+++ b/ims/ostis_tech/unificated_models/section_unificated_models_kb/section_subjdomain_of_logical_formulas_and_logical_ontologies/subject_domain_of_logical_formulas_and_logical_ontologies.scsi
@@ -320,9 +320,6 @@ statement <- sc_node_not_relation;
 => nrel_idtf:
 	[текст логической формулы] (* <- lang_ru;; *);
 
-<= nrel_inclusion: 
-	semantic_neighborhood;
-
 <- rrel_key_sc_element:
 	...
 	(*

--- a/ims/ostis_tech/unificated_models/section_unificated_models_kb/section_subjdomain_semantic_neighborhoods/section_subject_domain_of_semantic_neighborhoods.scsi
+++ b/ims/ostis_tech/unificated_models/section_unificated_models_kb/section_subjdomain_semantic_neighborhoods/section_subject_domain_of_semantic_neighborhoods.scsi
@@ -235,6 +235,13 @@ specialized_semantic_neighborhood
 	logic_semantic_neighborhood;
 	description_of_a_typical_instance;
 	decomposition_description;
+	statement;
+	parametric_model;
+	task;
+	sc_description_of_sc_agent_behavior;
+	ui_descr_initiate_order;
+	ui_descr_oper_semantic_control;
+	ui_descr_oper_semantic_commands;
 <- rrel_key_sc_element:
 	...
 	(*

--- a/ims/ostis_tech/unificated_models/section_unificated_models_kpm/section_subject_domain_of_sc_agents/section_subject_domain_of_sc_agents.scsi
+++ b/ims/ostis_tech/unificated_models/section_unificated_models_kpm/section_subject_domain_of_sc_agents/section_subject_domain_of_sc_agents.scsi
@@ -507,7 +507,6 @@ sc_description_of_sc_agent_behavior
 		(* <- lang_ru;; *);
 		[sc-description of sc-agent behavior]
 		(* <- lang_en;; *);
-	<= nrel_inclusion: semantic_neighborhood;
 	<- rrel_key_sc_element:
 		...
 		(*  <- explanation;;

--- a/ui/model/ui_descr_initiate_order.scs
+++ b/ui/model/ui_descr_initiate_order.scs
@@ -1,7 +1,5 @@
 ui_descr_initiate_order 
 <- sc_node_not_relation;
-<= nrel_inclusion: 
-	semantic_neighborhood;
 
  => nrel_main_idtf:
 	[sc-описание способа инициирования с помощью элементарных пользовательских действий] (* <- lang_ru;; *);;

--- a/ui/model/ui_descr_oper_semantic_commands.scs
+++ b/ui/model/ui_descr_oper_semantic_commands.scs
@@ -1,7 +1,5 @@
 ui_descr_oper_semantic_commands
 <- sc_node_not_relation;
-<= nrel_inclusion: 
-	semantic_neighborhood;
 
  => nrel_main_idtf:
 	[sc-описание операционной семантики команд заданного класса] (* <- lang_ru;; *);;

--- a/ui/model/ui_descr_oper_semantic_control.scs
+++ b/ui/model/ui_descr_oper_semantic_control.scs
@@ -1,7 +1,5 @@
 ui_descr_oper_semantic_control
 <- sc_node_not_relation;
-<= nrel_inclusion: 
-	semantic_neighborhood;
 
  => nrel_main_idtf:
 	[sc-описание операционной семантики элемента управления] (* <- lang_ru;; *);;


### PR DESCRIPTION
исправлена иерархия семокрестности

>> Все, что связано с семокрестностью отношением включение нужно отвязать от нее и связать строгим включением со специализированной семокрестностью